### PR TITLE
Add Germany region and spots

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -56,7 +56,7 @@ http {
         }
 
         # SPA route support
-        location ~ ^/(login|capetown|tarifa|holland|sweden|myspots|myspots/edit)/?$ {
+    location ~ ^/(login|capetown|tarifa|holland|sweden|germany|myspots|myspots/edit)/?$ {
             root   /usr/share/nginx/html;
             try_files $uri $uri/ /index.html;
         }

--- a/fetch/region.mjs
+++ b/fetch/region.mjs
@@ -263,6 +263,23 @@ let regions = [
     ],
   },
   {
+    name: "germany",
+    from: 8,
+    to: 21,
+    spots: [
+      {
+        name: "Rügen - Suhrendorf",
+        slug: "ruegen-suhrendorf",
+        url: "https://www.windguru.cz/48115",
+      },
+      {
+        name: "Loissin",
+        slug: "loissin",
+        url: "https://www.windguru.cz/500783",
+      },
+    ],
+  },
+  {
     name: 'northernkites',
     from: 8,
     to: 21,

--- a/src/regionGradients.js
+++ b/src/regionGradients.js
@@ -3,6 +3,7 @@ export const regionGradients = {
   capetown: 'bg-gradient-to-br from-emerald-500 to-teal-500',
   holland: 'bg-gradient-to-br from-orange-500 to-amber-500',
   sweden: 'bg-gradient-to-br from-blue-500 to-indigo-500',
+  germany: 'bg-gradient-to-tl from-purple-400 to-indigo-500',
   myspots: 'bg-gradient-to-br from-amber-500 to-yellow-500',
 };
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -39,7 +39,7 @@ const routes = [
     component: Region,
     props: true,
     beforeEnter: (to, from, next) => {
-      ['capetown', 'tarifa', 'holland', 'myspots'].includes(to.params.region) && localStorage.setItem('lastRegion', to.params.region);
+      ['capetown', 'tarifa', 'holland', 'germany', 'myspots'].includes(to.params.region) && localStorage.setItem('lastRegion', to.params.region);
       if (to.params.region === 'myspots') {
         requireAuth(to, from, next);
       } else {

--- a/src/views/Region.vue
+++ b/src/views/Region.vue
@@ -11,7 +11,7 @@ const props = defineProps({
 });
 
 watch(() => props.region, (newRegion) => {
-  ['capetown', 'tarifa', 'holland', 'sweden', 'myspots'].includes(newRegion) && localStorage.setItem('lastRegion', newRegion);
+  ['capetown', 'tarifa', 'holland', 'sweden', 'germany', 'myspots'].includes(newRegion) && localStorage.setItem('lastRegion', newRegion);
 });
 </script>
 

--- a/src/views/RegionSelect.vue
+++ b/src/views/RegionSelect.vue
@@ -6,6 +6,7 @@ const availableRegions = [
   { id: 'holland', name: 'Holland', emoji: '🇳🇱' },
   { id: 'sweden', name: 'Sweden', emoji: '🇸🇪' },
   { id: 'tarifa', name: 'Tarifa', emoji: '🇪🇸' },
+  { id: 'germany', name: 'Germany', emoji: '🇩🇪' }
 ];
 </script>
 


### PR DESCRIPTION
## Add Germany region and spots

### Summary
- Add Germany region and two kite spots
- Update region selector and route allow‑list
- Add Germany gradient styling

### Testing
- `npm run fetch`
